### PR TITLE
Added 'this' keyword to enable builds to succeed

### DIFF
--- a/src/common/SerialStencilUtil.cpp
+++ b/src/common/SerialStencilUtil.cpp
@@ -18,7 +18,7 @@ SerialStencilValidater<T>::ValidateResult( const Matrix2D<T>& exp,
     valResultStr << validationErrors.size() << " validation errors";
     if( (validationErrors.size() > 0) && (nValErrsToPrint > 0) )
     {
-        PrintValidationErrors( valResultStr, validationErrors, nValErrsToPrint );
+        this->PrintValidationErrors( valResultStr, validationErrors, nValErrsToPrint );
     }
     std::cout << valResultStr.str() << std::endl;
 }

--- a/src/cuda/level1/stencil2d/CUDAStencilFactory.cpp
+++ b/src/cuda/level1/stencil2d/CUDAStencilFactory.cpp
@@ -16,13 +16,13 @@ CUDAStencilFactory<T>::BuildStencil( const OptionParser& options )
     size_t lRows;
     size_t lCols;
     std::vector<long long int> devs;
-    ExtractOptions( options,
-                    wCenter,
-                    wCardinal,
-                    wDiagonal,
-                    lRows,
-                    lCols,
-                    devs );
+    this->ExtractOptions( options,
+                          wCenter,
+                          wCardinal,
+                          wDiagonal,
+                          lRows,
+                          lCols,
+                          devs );
 
     // determine whcih device to use
     // We would really prefer this to be done in main() but

--- a/src/opencl/level1/stencil2d/OpenCLStencilFactory.cpp
+++ b/src/opencl/level1/stencil2d/OpenCLStencilFactory.cpp
@@ -17,12 +17,12 @@ OpenCLStencilFactory<T>::BuildStencil( const OptionParser& options )
     T wDiagonal;
     size_t lRows;
     size_t lCols;
-    ExtractOptions( options,
-                    wCenter,
-                    wCardinal,
-                    wDiagonal,
-                    lRows,
-                    lCols );
+    this->ExtractOptions( options,
+                          wCenter,
+                          wCardinal,
+                          wDiagonal,
+                          lRows,
+                          lCols );
 
     // build the stencil object
     return new OpenCLStencil<T>( wCenter, 


### PR DESCRIPTION
This fixes build errors like the following:

OpenCLStencilFactory.cpp: In instantiation of 'Stencil<T>\* OpenCLStencilFactory<T>::BuildStencil(const OptionParser&) [with T = double]':
Stencil2Dmain.cpp:466:1:   required from here
OpenCLStencilFactory.cpp:20:5: error: 'ExtractOptions' was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
OpenCLStencilFactory.cpp:20:5: note: declarations in dependent base 'CommonOpenCLStencilFactory<double>' are not found by unqualified lookup
OpenCLStencilFactory.cpp:20:5: note: use 'this->ExtractOptions' instead
