### PR TITLE
Fix some resource leaks in fftlib.c

### DIFF
--- a/src/opencl/level1/fft/FFT.cpp
+++ b/src/opencl/level1/fft/FFT.cpp
@@ -276,6 +276,7 @@ void runTest(const string& name,
     freeDeviceBuffer(chk);
     freeHostBuffer(source);
     freeHostBuffer(result);
+    deinit();
 }
 
 

--- a/src/opencl/level1/fft/fftlib.h
+++ b/src/opencl/level1/fft/fftlib.h
@@ -19,6 +19,7 @@ struct cplxdbl {
 };
 
 void init(OptionParser& op, bool dp);
+void deinit();
 void forward(void* work, int n_ffts);
 void inverse(void* work, int n_ffts);
 int check(void* work, void* check, int half_n_ffts, int half_n_cmplx);


### PR DESCRIPTION
The FFT benchmark leaks some of the resources allocated. On NVIDIA, this quickly exhausts the GPU memory when running the benchmark a few times with a large dataset. NVIDIA's OpenCL implementation doesn't seem to really release memory objects unless everything else has been released (see http://bloerg.net/2013/01/15/opencl-resource-management.html). This commit seems to plug the leaks. Please apply.
