### PR TITLE
Remove redundant -cl-unsafe-math-optimizations option.

### DIFF
--- a/src/opencl/level0/MaxFlops.cpp
+++ b/src/opencl/level0/MaxFlops.cpp
@@ -80,7 +80,7 @@ void addBenchmarkSpecOptions(OptionParser &op)
 // OpenCL compiler options -- default is to enable
 // all optimizations
 static const char* opts = "-cl-mad-enable -cl-no-signed-zeros "
-                          "-cl-unsafe-math-optimizations -cl-finite-math-only";
+                          "-cl-finite-math-only";
 
 // Forward Declarations
 // generate simple precision and double precision versions of the benchmarks


### PR DESCRIPTION
OpenCL spec (https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/clBuildProgram.html) says that "cl-unsafe-math-optimizations" option allows a lot of optimizations and generated source code of Add<N> tests can be completely optimized out. E.g.
```
s0=10.f-s0;
s0=10.f-s0;
```
can be optimized to
```
s0=s0;
```
when -cl-unsafe-math-optimizations is specified. At least clang compiler started to eliminate this code a time ago.

It seems for this trivial test the option should be removed in order to avoid such optimizations.