### PR TITLE
Fixed crash issue when running neuralnet

### DIFF
--- a/src/cuda/level1/neuralnet/NeuralNet.cu
+++ b/src/cuda/level1/neuralnet/NeuralNet.cu
@@ -631,7 +631,7 @@ void RunBenchmark(ResultDatabase &resultDB, OptionParser &op)
     free(TEST_DATA_Y);
     free(TRAINING_DATA_Y);
 
-    for (i=0; i<NUM_LAYERS; i++) {
+    for (i=1; i<NUM_LAYERS; i++) {
       free(ACTIVATIONS[i]);
     }
     free(ACTIVATIONS);


### PR DESCRIPTION
it will running into crash when running neuralnet bentchmak caused by a novalid point free operating.